### PR TITLE
Allow players to switch between their weapons if they have multiple in same slot

### DIFF
--- a/src/entities/entity_utilities.cpp
+++ b/src/entities/entity_utilities.cpp
@@ -231,3 +231,47 @@ Vector EntityUtilities::GetEntityAbsOrigin(CBaseEntity *entity) const
 
     return { originVector->x, originVector->y, originVector->z };
 }
+
+bool EntityUtilities::IsPrimaryWeaponClassName(const char *className) const
+{
+    // FIXME: Is there a way to figure this out dynamically without having to list all primary weapons here?
+    return strcmp("weapon_ak47", className) == 0
+            || strcmp("weapon_awp", className) == 0
+            || strcmp("weapon_m4a1", className) == 0
+            || strcmp("weapon_m4a1_silencer", className) == 0
+            || strcmp("weapon_sg556", className) == 0
+            || strcmp("weapon_aug", className) == 0
+            || strcmp("weapon_famas", className) == 0
+            || strcmp("weapon_g3sg1", className) == 0
+            || strcmp("weapon_scar20", className) == 0
+            || strcmp("weapon_galilar", className) == 0
+            || strcmp("weapon_ssg08", className) == 0
+            || strcmp("weapon_bizon", className) == 0
+            || strcmp("weapon_mac10", className) == 0
+            || strcmp("weapon_mp7", className) == 0
+            || strcmp("weapon_mp9", className) == 0
+            || strcmp("weapon_p90", className) == 0
+            || strcmp("weapon_ump45", className) == 0
+            || strcmp("weapon_mp5sd", className) == 0
+            || strcmp("weapon_m249", className) == 0
+            || strcmp("weapon_negev", className) == 0
+            || strcmp("weapon_sawedoff", className) == 0
+            || strcmp("weapon_mag7", className) == 0
+            || strcmp("weapon_nova", className) == 0
+            || strcmp("weapon_xm1014", className) == 0;
+}
+
+bool EntityUtilities::IsSecondaryWeaponClassName(const char *className) const
+{
+    // FIXME: Is there a way to figure this out dynamically without having to list all secondary weapons here?
+    return strcmp("weapon_usp_silencer", className) == 0
+            || strcmp("weapon_deagle", className) == 0
+            || strcmp("weapon_elite", className) == 0
+            || strcmp("weapon_fiveseven", className) == 0
+            || strcmp("weapon_glock", className) == 0
+            || strcmp("weapon_hkp2000", className) == 0
+            || strcmp("weapon_p250", className) == 0
+            || strcmp("weapon_tec9", className) == 0
+            || strcmp("weapon_cz75a", className) == 0
+            || strcmp("weapon_revolver", className) == 0;
+}

--- a/src/entities/entity_utilities.h
+++ b/src/entities/entity_utilities.h
@@ -40,6 +40,8 @@ public:
     CBaseEntity *FindEntityInListByClassName(const SourceHook::CVector<CBaseEntity *>& searchList, const char *className) const;
     Vector GetEntityAbsOrigin(CBaseEntity *entity) const;
     void KillEntity(CBaseEntity *entity);
+    bool IsPrimaryWeaponClassName(const char *className) const;
+    bool IsSecondaryWeaponClassName(const char *className) const;
 
 private:
     IGameHelpers *_gameHelpers { nullptr };

--- a/src/players/player.h
+++ b/src/players/player.h
@@ -147,6 +147,21 @@ public:
 
 private:
     unsigned int GetMoveTypeOffset() const;
+    bool HandleSwitchGrenade(
+            CUserCmd *command,
+            const char *weaponClassName,
+            const char *activeWeaponClassName,
+            const SourceHook::CVector<CBaseEntity*>& allWeapons);
+    bool HandleSwitchPrimaryWeapon(
+            CUserCmd *command,
+            const char *weaponClassName,
+            const char *activeWeaponClassName,
+            const SourceHook::CVector<CBaseEntity*>& allWeapons);
+    bool HandleSwitchSecondaryWeapon(
+            CUserCmd *command,
+            const char *weaponClassName,
+            const char *activeWeaponClassName,
+            const SourceHook::CVector<CBaseEntity*>& allWeapons);
 
     IGameHelpers *_gameHelpers { nullptr };
     ITimerSystem *_timerSystem { nullptr };


### PR DESCRIPTION
This commit allows players to switch between their primary and secondary weapons, even if they have more than one in a given slot.

It isn't perfect, but it should work if the player is using their number keys. It probably won't work as expected if a player is using their scroll wheel.

Fixes #4 