### PR TITLE
Add `Player::OnProjectileCreated`

### DIFF
--- a/src/hooks/projectile_create_hooks.h
+++ b/src/hooks/projectile_create_hooks.h
@@ -49,14 +49,14 @@ extern void *Hook_Original_MolotovProjectileCreate;
 extern void *Hook_Original_DecoyProjectileCreate;
 extern void *Hook_Original_HEGrenadeProjectileCreate;
 
-CBaseEntity *Hook_Call_SmokeProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
-CBaseEntity *Hook_Call_FlashbangProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
-CBaseEntity *Hook_Call_MolotovProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
-CBaseEntity *Hook_Call_DecoyProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
-CBaseEntity *Hook_Call_HEGrenadeProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
+CBaseEntity *Hook_Call_SmokeProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
+CBaseEntity *Hook_Call_FlashbangProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
+CBaseEntity *Hook_Call_MolotovProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
+CBaseEntity *Hook_Call_DecoyProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
+CBaseEntity *Hook_Call_HEGrenadeProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
 
 CBaseEntity* __cdecl Hook_Callback_ProjectileCreate(const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
-CBaseEntity* Hook_Call_Internal_ProjectileCreate(void *originalAddress, const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, void* player, int grenadeItemDefinitionIndex);
+CBaseEntity* Hook_Call_Internal_ProjectileCreate(void *originalAddress, const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, CBaseEntity *playerEntity, int grenadeItemDefinitionIndex);
 #else
 JEZ_HOOK_STATIC_DECL6(
         SmokeProjectileCreate,
@@ -70,8 +70,8 @@ JEZ_HOOK_STATIC_DECL6(
         velocity,
         const Vector&,
         angularImpulse,
-        void*,
-        player,
+        CBaseEntity*,
+        playerEntity,
         int,
         grenadeItemDefinitionIndex);
 
@@ -87,8 +87,8 @@ JEZ_HOOK_STATIC_DECL6(
         velocity,
         const Vector&,
         angularImpulse,
-        void*,
-        player,
+        CBaseEntity*,
+        playerEntity,
         int,
         grenadeItemDefinitionIndex);
 
@@ -104,8 +104,8 @@ JEZ_HOOK_STATIC_DECL6(
         velocity,
         const Vector&,
         angularImpulse,
-        void*,
-        player,
+        CBaseEntity*,
+        playerEntity,
         int,
         grenadeItemDefinitionIndex);
 
@@ -121,8 +121,8 @@ JEZ_HOOK_STATIC_DECL6(
         velocity,
         const Vector&,
         angularImpulse,
-        void*,
-        player,
+        CBaseEntity*,
+        playerEntity,
         int,
         grenadeItemDefinitionIndex);
 
@@ -138,8 +138,8 @@ JEZ_HOOK_STATIC_DECL6(
         velocity,
         const Vector&,
         angularImpulse,
-        void*,
-        player,
+        CBaseEntity*,
+        playerEntity,
         int,
         grenadeItemDefinitionIndex);
 

--- a/src/players/player.cpp
+++ b/src/players/player.cpp
@@ -488,7 +488,7 @@ QAngle Player::GetEyeAngles() const
     return Callables_Call_GetEyeAngles(playerEntity);
 }
 
-void Player::OnProjectileCreated(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, GrenadeType grenadeType)
+void Player::OnProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, GrenadeType grenadeType)
 {
     if(GetGrenadePlaybackStarted() || !GetGrenadePlaybackEnabled() || GetGrenadeAwaitingDetonation())
         return;
@@ -499,6 +499,16 @@ void Player::OnProjectileCreated(const Vector &origin, const QAngle &angle, cons
 
     SetProjectileParameters(ProjectileParameters(origin, angle, velocity, angularImpulse));
     SetGrenadeThrowerSpot(Spot(GetAbsOrigin(), GetEyeAngles()));
+}
+
+void Player::OnProjectileCreated(
+        const Vector &origin,
+        const QAngle &angle,
+        const Vector &velocity,
+        const Vector &angularImpulse,
+        GrenadeType grenadeType,
+        CBaseEntity *projectileEntity)
+{
 }
 
 bool Player::OnRunCmd(CUserCmd *command, IMoveHelper *moveHelper)

--- a/src/players/player.h
+++ b/src/players/player.h
@@ -113,7 +113,8 @@ public:
     CBaseEntity *GetEntity() const;
     SourceHook::CVector<CBaseEntity*> GetAllWeapons() const;
 
-    void OnProjectileCreated(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, GrenadeType grenadeType);
+    void OnProjectileCreate(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, GrenadeType grenadeType);
+    void OnProjectileCreated(const Vector &origin, const QAngle &angle, const Vector &velocity, const Vector &angularImpulse, GrenadeType grenadeType, CBaseEntity *projectileEntity);
     void OnGrenadeDetonationEvent(GrenadeType grenadeType, cell_t projectileReference);
     bool OnRunCmd(CUserCmd *command, IMoveHelper *moveHelper);
 


### PR DESCRIPTION
This commit adds a method inside the player class to notify when a projectile is created, which carries the `CBaseEntity*` of the projectile as a parameter.