### PR TITLE
Add credit to @rtldg for 64 tick grenade trick

### DIFF
--- a/src/hooks/cbasecsgrenade_start_grenade_throw_hook.cpp
+++ b/src/hooks/cbasecsgrenade_start_grenade_throw_hook.cpp
@@ -51,6 +51,8 @@ void Hook_Callback_CBaseCSGrenadeStartGrenadeThrow()
         throwTimeOffset = sendpropInfo.actual_offset;
     }
 
+    // Thanks to @rtldg for finding this trick!
+    // For more information, see: https://github.com/rtldg/64tick_nades
     float newValue = g_JabronEZ.GetGlobalVars()->curtime + 0.109375f;
     *(float*)((uint8_t *)weaponEntity + throwTimeOffset) = newValue;
 


### PR DESCRIPTION
This commit adds a comment to thank and credit @rtldg for the finding of the 64-tick grenade on a 128-tick server trick and math.